### PR TITLE
Restrict push to all branches to eclipse-jgit-bot

### DIFF
--- a/otterdog/eclipse-jgit.jsonnet
+++ b/otterdog/eclipse-jgit.jsonnet
@@ -28,6 +28,16 @@ orgs.newOrg('eclipse-jgit') {
   _repositories+:: [
     orgs.newRepo('jgit') {
       allow_merge_commit: true,
+      "branch_protection_rules": [
+        {
+          "allows_force_pushes": true,
+          "pattern": "*",
+          "push_restrictions": [
+            "eclipse-jgit-bot"
+          ],
+          "restricts_pushes": true
+        }
+      ],
       default_branch: "master",
       description: "JGit, the Java implementation of git",
       has_discussions: true,
@@ -39,6 +49,16 @@ orgs.newOrg('eclipse-jgit') {
     },
     orgs.newRepo('jgit-permissions') {
       allow_merge_commit: true,
+      "branch_protection_rules": [
+        {
+          "allows_force_pushes": true,
+          "pattern": "*",
+          "push_restrictions": [
+            "eclipse-jgit-bot"
+          ],
+          "restricts_pushes": true
+        }
+      ],
       default_branch: "master",
       description: "GerritHub permissions for JGit repositories",
       homepage: "https://www.eclipse.org/jgit/",
@@ -49,6 +69,16 @@ orgs.newOrg('eclipse-jgit') {
     },
     orgs.newRepo('jgit-pipelines') {
       allow_merge_commit: true,
+      "branch_protection_rules": [
+        {
+          "allows_force_pushes": true,
+          "pattern": "*",
+          "push_restrictions": [
+            "eclipse-jgit-bot"
+          ],
+          "restricts_pushes": true
+        }
+      ],
       default_branch: "master",
       description: "CI pipelines for JGit",
       has_discussions: true,
@@ -61,6 +91,16 @@ orgs.newOrg('eclipse-jgit') {
     orgs.newRepo('jgit-website') {
       allow_merge_commit: true,
       allow_update_branch: false,
+      "branch_protection_rules": [
+        {
+          "allows_force_pushes": true,
+          "pattern": "*",
+          "push_restrictions": [
+            "eclipse-jgit-bot"
+          ],
+          "restricts_pushes": true
+        }
+      ],
       default_branch: "master",
       delete_branch_on_merge: false,
       secret_scanning: "disabled",


### PR DESCRIPTION
This ensures changes are only done on eclipse.gerrithub.io and they are replicated 1:1 by the eclipse-jgit-bot user to the mirrored repos on github.com/eclipse-jgit.